### PR TITLE
Fix CMAKE_C_FLAGS setting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ OP-TEE Enabled Plug and Trust Library
 
 This repository provides the functionality required by a Trusted Execution Environment (in this case OP-TEE, v3.11 released on Oct 16 2020) to access the `NXP EdgeLock™ SE050: Plug & Trust Secure Element`.
 
-The relevant OP-TEE driver can be found at https://github.com/OP-TEE/optee_os/pull/4091.
+The relevant OP-TEE driver can be found at https://github.com/OP-TEE/optee_os/pull/4178.
 
 The stack has been validated on iMX8mm and iMX6ull platforms fitted with the ARD SE050 https://www.nxp.com/products/security-and-authentication/authentication/edgelock-se050-development-kit:OM-SE050X for the following operations::
 

--- a/optee_lib/CMakeLists.txt
+++ b/optee_lib/CMakeLists.txt
@@ -37,7 +37,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.5.0)
 project(se050)
 
-set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} ${FLAGS} "-std=gnu99 \
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS} -std=gnu99 \
                                     -fdiagnostics-show-option \
                                     -Wall -Os \
                                     -ffunction-sections -fdata-sections \

--- a/optee_lib/CMakeLists.txt
+++ b/optee_lib/CMakeLists.txt
@@ -6,8 +6,8 @@
 # Build AARCH64
 #  $ mkdir build
 #  $ cd build
-#  $ cmake -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DOPTEE_TREE=/path/to/optee/ ..
-#  $ make CFLAGS="-mstrict-align -mgeneral-regs-only"
+#  $ cmake -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_C_FLAGS="-mstrict-align -mgeneral-regs-only" -DOPTEE_TREE=/path/to/optee/ ..
+#  $ make
 #
 # Build ARM
 #  $ mkdir build


### PR DESCRIPTION
Faulty quote positioning led to list/semi-colon if FLAGS was pre-defined.