### PR TITLE
optee_lib: apdu tunnel

### DIFF
--- a/optee_lib/CMakeLists.txt
+++ b/optee_lib/CMakeLists.txt
@@ -97,6 +97,7 @@ FILE(
      glue/smCom.c
      glue/user.c
      glue/der.c
+     glue/apdu.c
 )
 
 add_library(${PROJECT_NAME} ${SOURCES})

--- a/optee_lib/glue/apdu.c
+++ b/optee_lib/glue/apdu.c
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (C) Foundries Ltd. 2021 - All Rights Reserved
+ * Author: Jorge Ramirez <jorge@foundries.io>
+ */
+
+#include <apdu.h>
+#include <string.h>
+
+sss_status_t sss_se05x_do_apdu(Se05xSession_t *ctx,
+			       enum se050_apdu_type type,
+			       uint8_t *header, size_t hdr_len,
+			       uint8_t *src_data, size_t src_len,
+			       uint8_t *dst_data, size_t *dst_len)
+{
+	smStatus_t status = SM_NOT_OK;
+	tlvHeader_t hdr = { 0 };
+
+	if (hdr_len != 4)
+		return kStatus_SSS_Fail;
+
+	hdr.hdr[0] = *(header + 0);
+	hdr.hdr[1] = *(header + 1);
+	hdr.hdr[2] = *(header + 2);
+	hdr.hdr[3] = *(header + 3);
+
+	switch (type) {
+	case SE050_APDU_NONE:
+		status = DoAPDUTxRx(ctx, src_data, src_len, dst_data, dst_len);
+		break;
+	case SE050_APDU_TYPE_0:
+	case SE050_APDU_TYPE_1:
+	case SE050_APDU_TYPE_2:
+		status = DoAPDUTxRx_s_Case2(ctx, &hdr, src_data, src_len,
+					    dst_data, dst_len);
+		break;
+	case SE050_APDU_TYPE_3:
+	case SE050_APDU_TYPE_5:
+		status = DoAPDUTxRx_s_Case4(ctx, &hdr, src_data, src_len,
+					    dst_data, dst_len);
+		break;
+	case SE050_APDU_TYPE_4:
+	case SE050_APDU_TYPE_6:
+		status = DoAPDUTxRx_s_Case4_ext(ctx, &hdr, src_data, src_len,
+						dst_data, dst_len);
+		break;
+	default:
+		return kStatus_SSS_Fail;
+	}
+
+	if (status != SM_OK)
+		return kStatus_SSS_Fail;
+
+	return kStatus_SSS_Success;
+}

--- a/optee_lib/glue/include/apdu.h
+++ b/optee_lib/glue/include/apdu.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) Foundries Ltd. 2021 - All Rights Reserved
+ * Author: Jorge Ramirez <jorge@foundries.io>
+ */
+
+#ifndef APDU_H
+#define APDU_H
+
+#include "apduComm.h"
+#include <fsl_sss_api.h>
+#include "se05x_tlv.h"
+
+enum se050_apdu_type {
+	SE050_APDU_TYPE_0 = APDU_TXRX_CASE_1,
+	SE050_APDU_TYPE_1 = APDU_TXRX_CASE_2,
+	SE050_APDU_TYPE_2 = APDU_TXRX_CASE_2E,
+	SE050_APDU_TYPE_3 = APDU_TXRX_CASE_3,
+	SE050_APDU_TYPE_4 = APDU_TXRX_CASE_3E,
+	SE050_APDU_TYPE_5 = APDU_TXRX_CASE_4,
+	SE050_APDU_TYPE_6 = APDU_TXRX_CASE_4E,
+	SE050_APDU_NONE = APDU_TXRX_CASE_INVALID,
+};
+
+sss_status_t sss_se05x_do_apdu(Se05xSession_t *ctx,
+			       enum se050_apdu_type type,
+			       uint8_t *hdr, size_t hdr_len,
+			       uint8_t *src_data, size_t src_len,
+			       uint8_t *dst_data, size_t *dst_len);
+#endif /* APDU_H */

--- a/optee_lib/include/apdu.h
+++ b/optee_lib/include/apdu.h
@@ -1,0 +1,1 @@
+../glue/include/apdu.h


### PR DESCRIPTION
Allow an external trusted application to send APDU raw frames back to
OP-TEE for SCP03 encryption and I2C transmission.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>